### PR TITLE
Typo: softed --> sorted

### DIFF
--- a/draft-toomim-httpbis-braid-http-01.txt
+++ b/draft-toomim-httpbis-braid-http-01.txt
@@ -182,7 +182,7 @@ Table of Contents
    [STRUCTURED-HEADERS].  Each string is a version.  For any two parent
    versions A and B that are specified in a Parents header, A cannot be
    a descendent of B or vice versa.  The ordering of versions in the
-   list carries no meaning, and SHOULD be softed lexicographically.
+   list carries no meaning, and SHOULD be sorted lexicographically.
 
    If a client or server does not specify a Version for a resource it
    transfers, the recipient MAY generate a new version ID of its own

--- a/old/draft-toomim-httpbis-braid-http-00.txt
+++ b/old/draft-toomim-httpbis-braid-http-00.txt
@@ -183,7 +183,7 @@ Table of Contents
    [STRUCTURED-HEADERS].  Each string is a version.  For any two parent
    versions A and B that are specified in a Parents header, A cannot be
    a descendent of B or vice versa.  The ordering of versions in the
-   list carries no meaning, and SHOULD be softed lexicographically.
+   list carries no meaning, and SHOULD be sorted lexicographically.
 
    If a client or server does not specify a Version for a resource it
    transfers, the recipient MAY generate a new version ID of its own


### PR DESCRIPTION
This PR fixes a typo: `softed` --> `sorted`