### PR TITLE
Remove extra colon.

### DIFF
--- a/draft-toomim-httpbis-braid-http-01.txt
+++ b/draft-toomim-httpbis-braid-http-01.txt
@@ -295,7 +295,7 @@ Table of Contents
 
    The previous example uses the Range Patch format, which is defined in
    [RANGE-PATCH].  However, one can use any patch format, by sending a
-   patch with a Content-Type: set to a patch format with a defined
+   patch with a Content-Type set to a patch format with a defined
    behavior, such as application/json-patch+json (as specified in
    [RFC6902]):
 

--- a/old/draft-toomim-httpbis-braid-http-00.txt
+++ b/old/draft-toomim-httpbis-braid-http-00.txt
@@ -296,7 +296,7 @@ Table of Contents
 
    The previous example uses the Range Patch format, which is defined in
    [RANGE-PATCH].  However, one can use any patch format, by sending a
-   patch with a Content-Type: set to a patch format with a defined
+   patch with a Content-Type set to a patch format with a defined
    behavior, such as application/json-patch+json (as specified in
    [RFC6902]):
 


### PR DESCRIPTION
This paragraph reads better without the extra colon `:` when describing the `Content-Type`, I was expected more example data after the colon, not a continuation of the paragraph itself.